### PR TITLE
stop 'kubectl port-forward' when the parent process (d8s) exits

### DIFF
--- a/pkg/run.go
+++ b/pkg/run.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"syscall"
 	"time"
 )
 
@@ -114,6 +115,10 @@ func portForward(ctx context.Context, localPort, dinnerPort int) error {
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Env = os.Environ()
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
 
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
closes #31